### PR TITLE
Use Doxray+Eleventy instead of KSS?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog & Release Notes
 
+## v0.1.0-beta.2 - 9/18/2019
+
+- Comment out reminders,
+  so that authors have to explicitly opt-in
+  case-by-case.
+- Add inline documentation comments
+  (marked with `@docs`)
+  using [Doxray](https://github.com/himedlooff/doxray)
+  and YAML format.
+- Exclude irrelevant files from npm releases
+- Typo fixes
+
+
 ## v0.1.0-beta.1 - 9/12/2019
 
 This is an incomplete set of remedies,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,10 @@ We'd love to have you contribute to this project.
 You can get involved by
 [creating or commenting on an issue](https://github.com/mozdevs/cssremedy/issues).
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. For more details, please read the [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
+This repository is governed by Mozilla's
+code of conduct and etiquette guidelines.
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
 
 ## Pull Reguests
 
@@ -14,14 +17,57 @@ and submitting new remedies.
 For larger changes,
 it's often best to file an issue for discussion first.
 
+### Organization
+
 The code is organized into:
 
-- A core `remedy.css` that we recommend using broadly across most projects.
-- A secondary `reminders.css` with more opinionated or situational remedies that should be reviewed and considered on a case-by-case basis.
-- Additional specialized remedy files (such as `quotes.css`) that can be used as-needed, but may not be required generally.
+- A core `remedy.css`
+  that we recommend using broadly across most projects.
+- A secondary `reminders.css`
+  with more opinionated or potentially dangerous remedies
+  that should be reviewed and considered on a case-by-case basis.
+  All reminders are commented out by default.
+- Additional specialized remedy files
+  (such as `quotes.css`) that can be used as-needed,
+  but may not be useful generally.
 
 The `process` folder contains related materials:
 
 - Other resets
 - UA stylesheets from various browsers
 - An html file to test against
+
+### Documentation
+
+We're using code comments with
+[Doxray](https://github.com/himedlooff/doxray)
+to automatically generate our online documentation.
+Comments start with `/* doxray`,
+and use [YAML](https://learnxinyminutes.com/docs/yaml/) structure,
+and [Markdown](https://commonmark.org/help/)
+for notes.
+It looks like this:
+
+```
+/* doxray
+label: Name The Remedy (required)
+
+note: |
+  Indented markdown note can include
+  any [links](http://mozilla.org/) and
+  *other* `markdown` **syntax** (recommended).
+
+  The vertical bar `|` at the start of the note block
+  allows the note to span multiple lines.
+
+links:
+  - https://example.com/any-relevant-links-including-github-discussion/
+  - (optional)
+
+category: name groups of remedies (required)
+*/
+```
+
+Every file should start with a file-level
+comment that describes the contents of that file,
+using `category: file`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ code of conduct and etiquette guidelines.
 For more details, please read the
 [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
 
-## Pull Reguests
+## Pull Requests
 
 We're also happy to take pull requests,
 both for fixing bugs/typos
@@ -48,7 +48,7 @@ and [Markdown](https://commonmark.org/help/)
 for notes.
 It looks like this:
 
-```
+```css
 /* doxray
 label: Name The Remedy (required)
 
@@ -62,12 +62,49 @@ note: |
 
 links:
   - https://example.com/any-relevant-links-including-github-discussion/
+  - https://example.com/links-are-recommended
+
+todo: |
+  Add a `markdown` block
+  with todo items releated to this remedy.
+
+  - You can add lists in the markdown,
+    but this is not the same as the `links` YAML list...
   - (optional)
 
-category: name groups of remedies (required)
+category: create groups (required)
 */
 ```
 
 Every file should start with a file-level
-comment that describes the contents of that file,
-using `category: file`.
+comment that describes the purpose
+and contents of that file:
+
+```css
+/* doxray
+label: Name The File (required)
+version: 0.1.0-beta.1 (required)
+
+note: |
+  Describe the purpose & contents of the file (recommended).
+
+category: file (!important)
+```
+
+Adding `category: file` marks it as a file-level comment.
+We also include a `version` number on every file,
+since CSS documents are likely to be coppied and pasted
+out-of-context.
+
+## Release Checklist
+
+- [ ] Update inline documentation comments as needed
+- [ ] Update `CHANGELOG.md` with bugfixes, new remedies, and breaking changes
+- [ ] Update version using [SemVer](https://semver.org/), and record in:
+  - [ ] `package.json`
+  - [ ] `CHANGELOG.md`
+  - [ ] CSS file-level comments
+- [ ] If possible, run RemeDocs locally to test documentation build
+- [ ] Merge changes into the `master` branch
+- [ ] Create a release on GitHub
+- [ ] Publish release on NPM

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ and contents of that file:
 ```css
 /* @docs
 label: Name The File (required)
-version: 0.1.0-beta.1 (required)
+version: 3.0.1-beta.1 (required)
 
 note: |
   Describe the purpose & contents of the file (recommended).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,14 +42,14 @@ The `process` folder contains related materials:
 We're using code comments with
 [Doxray](https://github.com/himedlooff/doxray)
 to automatically generate our online documentation.
-Comments start with `/* doxray`,
+Comments start with `/* @docs`,
 and use [YAML](https://learnxinyminutes.com/docs/yaml/) structure,
 and [Markdown](https://commonmark.org/help/)
 for notes.
 It looks like this:
 
 ```css
-/* doxray
+/* @docs
 label: Name The Remedy (required)
 
 note: |
@@ -81,7 +81,7 @@ comment that describes the purpose
 and contents of that file:
 
 ```css
-/* doxray
+/* @docs
 label: Name The File (required)
 version: 0.1.0-beta.1 (required)
 
@@ -98,13 +98,13 @@ out-of-context.
 
 ## Release Checklist
 
-- [ ] Update inline documentation comments as needed
-- [ ] Update `CHANGELOG.md` with bugfixes, new remedies, and breaking changes
-- [ ] Update version using [SemVer](https://semver.org/), and record in:
-  - [ ] `package.json`
-  - [ ] `CHANGELOG.md`
-  - [ ] CSS file-level comments
-- [ ] If possible, run RemeDocs locally to test documentation build
-- [ ] Merge changes into the `master` branch
-- [ ] Create a release on GitHub
-- [ ] Publish release on NPM
+- Update inline documentation comments as needed
+- Update `CHANGELOG.md` with bugfixes, new remedies, and breaking changes
+- Update version using [SemVer](https://semver.org/), and record in:
+  - `package.json`
+  - `CHANGELOG.md`
+  - CSS file-level comments
+- If possible, run RemeDocs locally to test documentation build
+- Merge changes into the `master` branch
+- Create a release on GitHub
+- Publish release on NPM

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ CSS Remedy takes a slightly different approach. These days, browsers are far mor
 
 You, however, don't have to stay in the past. You can override the UA styles with more modern ideas of how CSS should work by default. Introducing CSS Remedy.
 
-
-> ### “‘Because that’s what Mosaic did’ is exactly the kind of reasoning CSS Remedy is trying to leave behind.” — Eric Meyer
+> *‘Because that’s what Mosaic did’* is exactly the kind of reasoning CSS Remedy is trying to leave behind.
+>
+> ---Eric Meyer
 
 ## Guiding Ideas
 

--- a/css/quotes.css
+++ b/css/quotes.css
@@ -1,6 +1,6 @@
 /* @docs
 label: Quotes
-version: 0.1.0-beta.1
+version: 0.1.0-beta.2
 
 note: |
   This is what user agents are supposed to be doing for quotes,

--- a/css/quotes.css
+++ b/css/quotes.css
@@ -1,18 +1,29 @@
-/* This is what user agents are supposed to be doing for quotes, 
-according to https://html.spec.whatwg.org/multipage/rendering.html#quotes */
+/* doxray
+label: Quotes
 
-/*
+note: |
+  This is what user agents are supposed to be doing for quotes,
+  according to https://html.spec.whatwg.org/multipage/rendering.html#quotes
 
-I believe
+links:
+  - https://html.spec.whatwg.org/multipage/rendering.html#quotes
 
-:root:lang(af),       :not(:lang(af)) > :lang(af)             { quotes: '\201c' '\201d' '\2018' '\2019' }
-:root:lang(ak),       :not(:lang(ak)) > :lang(ak)             { quotes: '\201c' '\201d' '\2018' '\2019' }
-:root:lang(asa),      :not(:lang(asa)) > :lang(asa)           { quotes: '\201c' '\201d' '\2018' '\2019' }
+todo: |
+  I believe
 
-can be replaced by
+  ```css
+  :root:lang(af),       :not(:lang(af)) > :lang(af)             { quotes: '\201c' '\201d' '\2018' '\2019' }
+  :root:lang(ak),       :not(:lang(ak)) > :lang(ak)             { quotes: '\201c' '\201d' '\2018' '\2019' }
+  :root:lang(asa),      :not(:lang(asa)) > :lang(asa)           { quotes: '\201c' '\201d' '\2018' '\2019' }
+  ```
 
-:root:lang(af, ak, asa), [lang]:lang(af, ak, asa)       			{ quotes: '\201c' '\201d' '\2018' '\2019' }
+  can be replaced by
 
+  ```css
+  :root:lang(af, ak, asa), [lang]:lang(af, ak, asa)       			{ quotes: '\201c' '\201d' '\2018' '\2019' }
+  ```
+
+category: file
 */
 
 :root                                                         { quotes: '\201c' '\201d' '\2018' '\2019' } /* “ ” ‘ ’ */

--- a/css/quotes.css
+++ b/css/quotes.css
@@ -1,4 +1,4 @@
-/* doxray
+/* @docs
 label: Quotes
 version: 0.1.0-beta.1
 

--- a/css/quotes.css
+++ b/css/quotes.css
@@ -1,5 +1,6 @@
 /* doxray
 label: Quotes
+version: 0.1.0-beta.1
 
 note: |
   This is what user agents are supposed to be doing for quotes,

--- a/css/remedy.css
+++ b/css/remedy.css
@@ -1,4 +1,4 @@
-/* doxray
+/* @docs
 label: Core Remedies
 version: 0.1.0-beta.1
 
@@ -10,7 +10,7 @@ category: file
 */
 
 
-/* doxray
+/* @docs
 label: Box Sizing
 
 note: |
@@ -21,7 +21,7 @@ category: global
 *, ::before, ::after { box-sizing: border-box; }
 
 
-/* doxray
+/* @docs
 label: Line Sizing
 
 note: |
@@ -36,7 +36,7 @@ category: global
 html { line-sizing: normal; }
 
 
-/* doxray
+/* @docs
 label: Body Margins
 
 note: |
@@ -47,7 +47,7 @@ category: global
 body { margin: 0; }
 
 
-/* doxray
+/* @docs
 label: Heading Sizes
 
 note: |
@@ -63,7 +63,7 @@ h5 { font-size: 0.83rem; }
 h6 { font-size: 0.67rem; }
 
 
-/* doxray
+/* @docs
 label: H1 Margins
 
 note: |
@@ -74,7 +74,7 @@ category: typography
 h1 { margin: 0.67em 0; }
 
 
-/* doxray
+/* @docs
 label: Pre Wrapping
 
 note: |
@@ -85,7 +85,7 @@ category: typography
 pre { white-space: pre-wrap; }
 
 
-/* doxray
+/* @docs
 label: Horizontal Rule
 
 note: |
@@ -93,7 +93,7 @@ note: |
   2. Remove Firefox `color: gray`
   3. Remove default `1px` height, and common `overflow: hidden`
 
-  category: typography
+category: typography
 */
 hr {
   border-style: solid;
@@ -104,7 +104,7 @@ hr {
 }
 
 
-/* doxray
+/* @docs
 label: Responsive Embeds
 
 note: |
@@ -121,7 +121,7 @@ img, svg, video, canvas, audio, iframe, embed, object {
 }
 
 
-/* doxray
+/* @docs
 label: Aspect Ratios
 
 note: |
@@ -137,7 +137,7 @@ img, svg, video, canvas {
 }
 
 
-/* doxray
+/* @docs
 label: Audio Width
 
 note: |
@@ -149,7 +149,7 @@ category: embedded elements
 audio { width: 100%; }
 
 
-/* doxray
+/* @docs
 label: Image Borders
 
 note: |
@@ -160,7 +160,7 @@ category: legacy browsers
 img { border-style: none; }
 
 
-/* doxray
+/* @docs
 label: SVG Overflow
 
 note: |
@@ -171,7 +171,7 @@ category: legacy browsers
 svg { overflow: hidden; }
 
 
-/* doxray
+/* @docs
 label: HTML5 Elements
 
 note: |
@@ -184,7 +184,7 @@ article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
 }
 
 
-/* doxray
+/* @docs
 label: Checkbox & Radio Inputs
 
 note: |

--- a/css/remedy.css
+++ b/css/remedy.css
@@ -1,6 +1,6 @@
 /* @docs
 label: Core Remedies
-version: 0.1.0-beta.1
+version: 0.1.0-beta.2
 
 note: |
   These remedies are recommended

--- a/css/remedy.css
+++ b/css/remedy.css
@@ -1,5 +1,6 @@
 /* doxray
 label: Core Remedies
+version: 0.1.0-beta.1
 
 note: |
   These remedies are recommended

--- a/css/remedy.css
+++ b/css/remedy.css
@@ -1,24 +1,59 @@
-/* Global Remedies
-******************/
+/* doxray
+label: Core Remedies
 
-/* Use border-box by default, globally */
+note: |
+  These remedies are recommended
+  as a starter for any project.
+
+category: file
+*/
+
+
+/* doxray
+label: Box Sizing
+
+note: |
+  Use border-box by default, globally.
+
+category: global
+*/
 *, ::before, ::after { box-sizing: border-box; }
 
-/*
-* Consistent line spacing...
-* CSS Inline Layout Module Level 3: https://drafts.csswg.org/css-inline-3/#line-sizing-property
+
+/* doxray
+label: Line Sizing
+
+note: |
+  Consistent line-spacing,
+  even when inline elements have different line-heights.
+
+links:
+  - https://drafts.csswg.org/css-inline-3/#line-sizing-property
+
+category: global
 */
 html { line-sizing: normal; }
 
-/* Remove the tiny space around the edge of the page */
+
+/* doxray
+label: Body Margins
+
+note: |
+  Remove the tiny space around the edge of the page.
+
+category: global
+*/
 body { margin: 0; }
 
 
-/* Headings
-***********/
+/* doxray
+label: Heading Sizes
 
-/* Switch to rem units for headings */
-/* @@@ Initial values are based on existing browser defaults */
+note: |
+  Switch to rem units for headings
+
+category: typography
+*/
 h1 { font-size: 2rem; }
 h2 { font-size: 1.5rem; }
 h3 { font-size: 1.17rem; }
@@ -26,20 +61,38 @@ h4 { font-size: 1.00rem; }
 h5 { font-size: 0.83rem; }
 h6 { font-size: 0.67rem; }
 
-/* Keep h1 margins consistent, even when nested */
+
+/* doxray
+label: H1 Margins
+
+note: |
+  Keep h1 margins consistent, even when nested.
+
+category: typography
+*/
 h1 { margin: 0.67em 0; }
 
 
-/* Typography
-*************/
+/* doxray
+label: Pre Wrapping
 
-/* Overflow by default is bad */
+note: |
+  Overflow by default is bad...
+
+category: typography
+*/
 pre { white-space: pre-wrap; }
 
-/*
-* 1. Solid, thin horizontal rules
-* 2. Remove Firefox `color: gray`
-* 3. Remove default `1px` height, and common `overflow: hidden`
+
+/* doxray
+label: Horizontal Rule
+
+note: |
+  1. Solid, thin horizontal rules
+  2. Remove Firefox `color: gray`
+  3. Remove default `1px` height, and common `overflow: hidden`
+
+  category: typography
 */
 hr {
   border-style: solid;
@@ -50,13 +103,15 @@ hr {
 }
 
 
-/* Embedded Elements
-********************/
+/* doxray
+label: Responsive Embeds
 
-/*
-* 1. Block display is usually what we want
-* 2. Remove strange space-below when inline
-* 3. Responsive by default
+note: |
+  1. Block display is usually what we want
+  2. Remove strange space-below when inline
+  3. Responsive by default
+
+category: embedded elements
 */
 img, svg, video, canvas, audio, iframe, embed, object {
   display: block;
@@ -64,38 +119,78 @@ img, svg, video, canvas, audio, iframe, embed, object {
   max-width: 100%;
 }
 
-/*
-* Maintain intrinsic aspect ratios when `max-width` is applied
-* (iframe, embed, and object have no intrinsic ratio, set height explicitly)
+
+/* doxray
+label: Aspect Ratios
+
+note: |
+  Maintain intrinsic aspect ratios when `max-width` is applied.
+  `iframe`, `embed`, and `object` are also embedded,
+  but have no intrinsic ratio,
+  so their `height` needs to be set explicitly.
+
+category: embedded elements
 */
 img, svg, video, canvas {
   height: auto;
 }
 
-/*
-* There is no good reason elements default to 300px,
-* and audio files are unlikely to come with a width attribute
+
+/* doxray
+label: Audio Width
+
+note: |
+  There is no good reason elements default to 300px,
+  and audio files are unlikely to come with a width attribute.
+
+category: embedded elements
 */
 audio { width: 100%; }
 
 
-/* Old Browsers
-***************/
+/* doxray
+label: Image Borders
 
-/* Remove the border on images inside links in IE 10 and earlier */
+note: |
+  Remove the border on images inside links in IE 10 and earlier.
+
+category: legacy browsers
+*/
 img { border-style: none; }
 
-/* Hide the overflow in IE 10 and earlier */
+
+/* doxray
+label: SVG Overflow
+
+note: |
+  Hide the overflow in IE 10 and earlier.
+
+category: legacy browsers
+*/
 svg { overflow: hidden; }
 
-/* Default block display on HTML5 elements */
+
+/* doxray
+label: HTML5 Elements
+
+note: |
+  Default block display on HTML5 elements
+
+category: legacy browsers
+*/
 article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
   display: block;
 }
 
-/*
-* 1. Add the correct box sizing in IE 10
-* 2. Remove the padding in IE 10
+
+/* doxray
+label: Checkbox & Radio Inputs
+
+note: |
+  1. Add the correct box sizing in IE 10
+  2. Remove the padding in IE 10
+
+category: legacy browsers
 */
 [type='checkbox'],
 [type='radio'] {

--- a/css/reminders.css
+++ b/css/reminders.css
@@ -77,13 +77,23 @@ label: Line Heights
 
 note: |
   The default `normal` line-height is tightly spaced,
-  but takes font-metrics into account --
+  but takes font-metrics into account,
   which is important for many fonts.
-  Looser spacing may improve readability,
-  but may also cause problems in some scripts.
+  Looser spacing may improve readability in latin type,
+  but may cause problems in some scripts --
+  from cusrive/fantasy fonts to
+  [Javanese](https://jsbin.com/bezasax/1/edit?html,css,output),
+  [Persian](https://jsbin.com/qurecom/edit?html,css,output),
+  and CJK languages.
 
 links:
   - https://github.com/mozdevs/cssremedy/issues/7
+  - https://jsbin.com/bezasax/1/edit?html,css,output
+  - https://jsbin.com/qurecom/edit?html,css,output
+
+todo:
+  - Use `:lang(language-code)` selectors?
+  - Add typography remedies for other scripts & languages...
 
 category: typography
 */

--- a/css/reminders.css
+++ b/css/reminders.css
@@ -1,4 +1,4 @@
-/* doxray
+/* @docs
 label: Reminders
 version: 0.1.0-beta.1
 
@@ -14,7 +14,7 @@ category: file
 */
 
 
-/* doxray
+/* @docs
 label: List Style
 
 note: |
@@ -31,7 +31,7 @@ category: navigation
 } */
 
 
-/* doxray
+/* @docs
 label: List Voiceover
 
 note: |
@@ -49,7 +49,7 @@ category: navigation
 } */
 
 
-/* doxray
+/* @docs
 label: Reduced Motion
 
 note: |
@@ -73,7 +73,7 @@ category: accessibility
 } */
 
 
-/* doxray
+/* @docs
 label: Line Heights
 
 note: |

--- a/css/reminders.css
+++ b/css/reminders.css
@@ -1,42 +1,66 @@
-/*
-* These are not universally recommended remedies,
-* but they are good to consider,
-* and they might work for you.
+/* doxray
+label: Reminders
+
+note: |
+  All the remedies in this file are commented out by default,
+  because they could cause harm as general defaults.
+  These should be used as reminders
+  to handle common styling issues
+  in a way that will work for your project and users.
+  Read, explore, uncomment, and edit as needed.
+
+category: file
 */
 
 
-/* Nav Lists
-************/
+/* doxray
+label: List Style
 
-/*
-* List styling is not usually desired in navigation,
-* but this also removes list-semantics for screen-readers
-* See: https://github.com/mozdevs/cssremedy/issues/15
+note: |
+  List styling is not usually desired in navigation,
+  but this also removes list-semantics for screen-readers
+
+links:
+  - https://github.com/mozdevs/cssremedy/issues/15
+
+category: navigation
 */
-nav ul {
+/* nav ul {
   list-style: none;
-}
+} */
 
-/*
-* 1. Add zero-width-space to prevent VoiceOver disable
-* 2. Absolute position ensures no extra space
-* See: https://unfetteredthoughts.net/2017/09/26/voiceover-and-list-style-type-none/
+
+/* doxray
+label: List Voiceover
+
+note: |
+  1. Add zero-width-space to prevent VoiceOver disable
+  2. Absolute position ensures no extra space
+
+links:
+  - https://unfetteredthoughts.net/2017/09/26/voiceover-and-list-style-type-none/
+
+category: navigation
 */
-nav li:before {
+/* nav li:before {
   content: "\200B";
   position: absolute;
-}
+} */
 
 
-/* Reduced Motion
-*****************/
+/* doxray
+label: Reduced Motion
 
-/*
-* 1. Immediately jump any animation to the end point
-* 2. Remove transitions & fixed background attachment
-* See: https://github.com/mozdevs/cssremedy/issues/11
+note: |
+  1. Immediately jump any animation to the end point
+  2. Remove transitions & fixed background attachment
+
+links:
+  - https://github.com/mozdevs/cssremedy/issues/11
+
+category: accessibility
 */
-@media (prefers-reduced-motion: reduce) {
+/* @media (prefers-reduced-motion: reduce) {
   *, ::before, ::after {
     animation-delay: -1s !important;
     animation-duration: 1s !important;
@@ -45,17 +69,24 @@ nav li:before {
     scroll-behavior: auto !important;
     transition-duration: 0s !important;
   }
-}
+} */
 
 
-/* Line Heights
-***************/
+/* doxray
+label: Line Heights
 
-/*
-* The default `normal` line-height is tightly spaced, but takes font-metrics into account.
-* Looser spacing may improve readability, but may cause problems in some scripts.
-* See: https://github.com/mozdevs/cssremedy/issues/7
+note: |
+  The default `normal` line-height is tightly spaced,
+  but takes font-metrics into account --
+  which is important for many fonts.
+  Looser spacing may improve readability,
+  but may also cause problems in some scripts.
+
+links:
+  - https://github.com/mozdevs/cssremedy/issues/7
+
+category: typography
 */
-html { line-height: 1.5; }
+/* html { line-height: 1.5; }
 h1, h2, h3, h4, h5, h6 { line-height: 1.25; }
-caption, figcaption, label, legend { line-height: 1.375; }
+caption, figcaption, label, legend { line-height: 1.375; } */

--- a/css/reminders.css
+++ b/css/reminders.css
@@ -1,5 +1,6 @@
 /* doxray
 label: Reminders
+version: 0.1.0-beta.1
 
 note: |
   All the remedies in this file are commented out by default,
@@ -91,7 +92,7 @@ links:
   - https://jsbin.com/bezasax/1/edit?html,css,output
   - https://jsbin.com/qurecom/edit?html,css,output
 
-todo:
+todo: |
   - Use `:lang(language-code)` selectors?
   - Add typography remedies for other scripts & languages...
 

--- a/css/reminders.css
+++ b/css/reminders.css
@@ -1,6 +1,6 @@
 /* @docs
 label: Reminders
-version: 0.1.0-beta.1
+version: 0.1.0-beta.2
 
 note: |
   All the remedies in this file are commented out by default,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssremedy",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "Start your project with a remedy for the technical debt of CSS",
   "repository": "mozdevs/cssremedy",
   "author": "Mozilla Developer Relations",


### PR DESCRIPTION
- [Doxray](https://github.com/himedlooff/doxray) is a light-weight comment-parser, that transforms YAML into json
- [Eleventy](https://www.11ty.io/) is a flexible static-site generator that can build out pages based on that json, and also grow to include any other site content we want

Currently I have them built together in a proof-of-concept at [mirisuzanne/remedocs]
(https://github.com/mirisuzanne/remedocs) (not a final home for it). I think this will work well for us, but there are a few issues still to solve:

- [x] Should the doxray compilation happen inside the `cssremedy` repo? That would allow us to run CI tests on the doc step before merging changes, and also create a single access point for the static file to load all necessary data. Alternately, it might be nice to keep all the doc build steps outside of this repo. *UPDATE: planning to keep the entire build-step inside remedocs for now.*
- [ ] Once the `cssremedy` package is released, I'll need to setup the build step for importing the remedy files (or pre-compiled docs file) into remedocs. That should be straight-forward.
- [ ] We should move remedocs to… the `mozdevs` org here on github? We could potentially deploy to gh-pages, or use Netlify to set up a more automated build cycle.

(I'd also love if we could use something more clear than `/* doxray` to mark documentation comments, so I [opened an issue over there](https://github.com/himedlooff/doxray/issues/22)… We'll see…)

Issues:
- Closes #58
- Closes #53 once we get it done…
- Improvements on #7 I think, but not ready to close…