### PR TITLE
Respect the default `hidden` attribute behaviour

### DIFF
--- a/css/remedy.css
+++ b/css/remedy.css
@@ -78,6 +78,8 @@ img, svg, video, canvas {
 */
 audio { width: 100%; }
 
+/** Maintain `hidden` behaviour on our display styles. */
+[hidden] { display: none; }
 
 /* Old Browsers
 ***************/


### PR DESCRIPTION
https://github.com/mozdevs/cssremedy/issues/71

This PR aims to respect the default `hidden` attribute behaviour.

I also tried something along the lines of
```css
img:not([hidden]), svg:not([hidden]), video:not([hidden]), canvas:not([hidden]), audio:not([hidden]), iframe:not([hidden]), embed:not([hidden]), object:not([hidden]), article:not([hidden]), aside:not([hidden]), figcaption:not([hidden]), figure:not([hidden]), footer:not([hidden]), header:not([hidden]), hgroup:not([hidden]), main:not([hidden]), nav:not([hidden]), section:not([hidden]) { display: block; }
```
but I figured it would be way too bulky