### PR TITLE
Clarify the role of warned vertical-align

### DIFF
--- a/css/remedy.css
+++ b/css/remedy.css
@@ -120,7 +120,7 @@ label: Responsive Embeds
 
 note: |
   1. Block display is usually what we want
-  2. Remove strange space-below in case authors overwrite the display value
+  2. The `vertical-align` removes strange space-below in case authors overwrite the display value
   3. Responsive by default
   4. Audio without `[controls]` remains hidden by default
 


### PR DESCRIPTION
The vertical-align for replaced elements is incorrectly warned by some editors built-in linting (afaik VSCode), saying it's useless when using with block display. However, this is completely expected: https://github.com/jensimmons/cssremedy/issues/14

I just think that the comment is a little bit confusing at first. Mentioning the property name would help!