### PR TITLE
fix(remedy): remove outdated line-sizing

### DIFF
--- a/css/remedy.css
+++ b/css/remedy.css
@@ -22,21 +22,6 @@ category: global
 
 
 /* @docs
-label: Line Sizing
-
-note: |
-  Consistent line-spacing,
-  even when inline elements have different line-heights.
-
-links:
-  - https://drafts.csswg.org/css-inline-3/#line-sizing-property
-
-category: global
-*/
-html { line-sizing: normal; }
-
-
-/* @docs
 label: Body Margins
 
 note: |


### PR DESCRIPTION
"Changes since the 4 June 2020 Working Draft include:...Reworked the relationship of the earlier line-sizing and leading-trim proposals to create text-edge and a differently-structured leading-trim. (Issue 5168)" (https://drafts.csswg.org/css-inline-3/#changes). Perhaps `text-edge` and `leading-trim` could be added for future support in safe way.